### PR TITLE
No need to require at the top of authenticated controller as of 0.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/simplabs/rails_api_auth.git
-  revision: 3fedc5cc98fc12086ba65dc3b181755b057e8fc6
+  revision: cd91fee4a1fd532038f7d1f28227fee3a822d048
   specs:
-    rails_api_auth (0.0.3)
+    rails_api_auth (0.0.4)
       bcrypt (~> 3.1.7)
       httparty (~> 0.13.3)
       rails (>= 3.2.6, < 5)
@@ -46,8 +46,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
-    bcrypt (3.1.10)
+    bcrypt (3.1.11)
     builder (3.2.2)
+    concurrent-ruby (1.0.1)
     dotenv (2.0.2)
     dotenv-rails (2.0.2)
       dotenv (= 2.0.2)
@@ -55,7 +56,7 @@ GEM
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    httparty (0.13.5)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
@@ -64,12 +65,12 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.6.1)
-    mini_portile (0.6.2)
-    minitest (5.8.0)
+    mime-types (2.99.1)
+    mini_portile2 (2.0.0)
+    minitest (5.8.4)
     multi_xml (0.5.5)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -90,21 +91,22 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.2)
+    rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     railties (4.2.3)
       actionpack (= 4.2.3)
       activesupport (= 4.2.3)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rake (11.1.1)
     spring (1.3.6)
-    sprockets (3.3.4)
-      rack (~> 1.0)
-    sprockets-rails (2.3.2)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -120,6 +122,3 @@ DEPENDENCIES
   rails_api_auth!
   spring
   sqlite3
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,5 +1,3 @@
-require 'rails_api_auth/authentication'
-
 class AuthenticatedController < ApplicationController
 
   include RailsApiAuth::Authentication

--- a/config/initializers/rails_api_auth.rb
+++ b/config/initializers/rails_api_auth.rb
@@ -3,6 +3,5 @@ RailsApiAuth.tap do |raa|
 
   raa.facebook_app_id       = ENV['FACEBOOK_APP_ID']
   raa.facebook_app_secret   = ENV['FACEBOOK_APP_SECRET']
-  raa.facebook_graph_url    = 'https://graph.facebook.com'
   raa.facebook_redirect_uri = 'http://localhost:3000/'
 end


### PR DESCRIPTION
Also, apparently something changed with the facebook_url, so I needed to take that out of the initializer.
